### PR TITLE
Fix encoding issue for Ruby 2.x

### DIFF
--- a/apktools.gemspec
+++ b/apktools.gemspec
@@ -18,13 +18,13 @@
 
 Gem::Specification.new do |s|
   s.name        = 'apktools'
-  s.version     = '0.7.0'
-  s.date        = '2016-02-17'
+  s.version     = '0.7.1'
+  s.date        = '2016-02-22'
   s.summary     = 'APKTools'
   s.description = 'Library to assist reading resource data out of Android APKs'
   s.authors     = ['Dave Smith']
   s.email       = 'smith@wiresareobsolete.com'
-  s.files       = ["lib/apktools/apkresources.rb", "lib/apktools/apkxml.rb", "lib/apktools/resconfiguration.rb"]
+  s.files       = %w(lib/apktools/apkresources.rb lib/apktools/apkxml.rb lib/apktools/resconfiguration.rb)
   s.homepage    = 'http://github.com/devunwired/apktools'
   s.license     = 'MIT'
 

--- a/lib/apktools/apkresources.rb
+++ b/lib/apktools/apkresources.rb
@@ -137,7 +137,7 @@ class ApkResources
     # Get resources.arsc from the APK file
     Zip::File.foreach(apk_file) do |f|
       if f.name.match(/resources.arsc/)
-        data = f.get_input_stream.read.bytes
+        data = f.get_input_stream.read.force_encoding('BINARY')
       end
     end
 

--- a/lib/apktools/apkresources.rb
+++ b/lib/apktools/apkresources.rb
@@ -137,7 +137,7 @@ class ApkResources
     # Get resources.arsc from the APK file
     Zip::File.foreach(apk_file) do |f|
       if f.name.match(/resources.arsc/)
-      data = f.get_input_stream.read
+        data = f.get_input_stream.read.bytes
       end
     end
 

--- a/lib/apktools/apkxml.rb
+++ b/lib/apktools/apkxml.rb
@@ -136,7 +136,7 @@ class ApkXml
     # Get the XML from the APK file
     Zip::File.foreach(@current_apk) do |f|
       if f.name.match(xml_file)
-      data = f.get_input_stream.read
+        data = f.get_input_stream.read.force_encoding('BINARY')
       end
     end
 


### PR DESCRIPTION
Ruby 2.x started to interpret .read as UTF-8 encoded default string, where as Ruby 1.9.3 used ASCII-US7Bit

By using in both cases the raw byte array (.bytes) we circumvent the String interpretation and can correctly parse it without jumping multiple bytes in between some substring selection via the array operator [].

This adresses issue #12 