### PR TITLE
Fix warnings on invalid date raised by RubyZip

### DIFF
--- a/apktools.gemspec
+++ b/apktools.gemspec
@@ -18,8 +18,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'apktools'
-  s.version     = '0.7.1'
-  s.date        = '2016-02-22'
+  s.version     = '0.7.2'
+  s.date        = '2017-04-03'
   s.summary     = 'APKTools'
   s.description = 'Library to assist reading resource data out of Android APKs'
   s.authors     = ['Dave Smith']
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
 
   s.executables << 'get_app_version.rb'
   s.executables << 'read_manifest.rb'
-  s.add_runtime_dependency 'rubyzip', '~> 1.1'
+  s.add_runtime_dependency 'rubyzip', '~> 1.2.1'
 end

--- a/lib/apktools/apkresources.rb
+++ b/lib/apktools/apkresources.rb
@@ -131,9 +131,10 @@ class ApkResources
   # Create a new ApkResources instance from the specified +apk_file+
   #
   # This opens and parses the contents of the APK's resources.arsc file.
-
   def initialize(apk_file)
     data = nil
+    Zip.warn_invalid_date = false
+
     # Get resources.arsc from the APK file
     Zip::File.foreach(apk_file) do |f|
       if f.name.match(/resources.arsc/)

--- a/lib/apktools/apkxml.rb
+++ b/lib/apktools/apkxml.rb
@@ -114,6 +114,7 @@ class ApkXml
   # This opens and parses the contents of the APK's resources.arsc file.
   def initialize(apk_file)
     @current_apk = apk_file
+    Zip.warn_invalid_date = false
     @apk_resources = ApkResources.new(apk_file)
   end #initialize
 
@@ -129,16 +130,17 @@ class ApkXml
   def parse_xml(xml_file, pretty = false, resolve_resources = false)
     # Reset variables
     @xml_elements = Array.new()
-    xml_output = ""
+    xml_output = ''
     indent = 0
     data = nil
 
-    # Get the XML from the APK file
+    Zip.warn_invalid_date = false
     Zip::File.foreach(@current_apk) do |f|
       if f.name.match(xml_file)
         data = f.get_input_stream.read.force_encoding('BINARY')
       end
     end
+
 
     # Parse the Header Chunk
     header = ChunkHeader.new( read_short(data, HEADER_START),


### PR DESCRIPTION
Hello,
The current version of the gem writes annoying "Invalid date/time in zip entry" warning messages to the standard output, effectively flooding the host ruby app's output. This is due to a bug/lack of configurability in the version of the RubyZip gem.

A fix exists in a later version of the RubyZip gem: this PR implements that fix and simply bumps the version number.