### PR TITLE
Update rubyzip gem

### DIFF
--- a/apktools.gemspec
+++ b/apktools.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
 
   s.executables << 'get_app_version.rb'
   s.executables << 'read_manifest.rb'
-  s.add_runtime_dependency 'rubyzip', '~> 1.2.1'
+  s.add_runtime_dependency 'rubyzip', '~> 1.2.2'
 end


### PR DESCRIPTION
rubyzip gem rubyzip version 1.2.1 and earlier contains a Directory Traversal vulnerability in Zip::File component that can result in write arbitrary files to the filesystem. This attack appear to be exploitable via If a site allows uploading of .zip files , an attacker can upload a malicious file that contains symlinks or files with absolute pathnames "../" to write arbitrary files to the filesystem

https://github.com/rubyzip/rubyzip/commit/d07b13a6cf0a413e010c48879aebd9576bfb5f68