### PR TITLE
Update rubyzip lib

### DIFF
--- a/apktools.gemspec
+++ b/apktools.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
 
   s.executables << 'get_app_version.rb'
   s.executables << 'read_manifest.rb'
-  s.add_runtime_dependency 'rubyzip', '1.3.0'
+  s.add_runtime_dependency 'rubyzip', '~> 1.3.0'
 end

--- a/apktools.gemspec
+++ b/apktools.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
 
   s.executables << 'get_app_version.rb'
   s.executables << 'read_manifest.rb'
-  s.add_runtime_dependency 'rubyzip', '~> 1.2.1'
+  s.add_runtime_dependency 'rubyzip', '1.3.0'
 end


### PR DESCRIPTION
The rubyzip lib has been updated and this has broken the compilation of your lib and aws_s3 lib that use your libs.

cause this erro 
`Error loading plugin 'fastlane-plugin-aws_s3': Unable to activate apktools-0.7.2, because rubyzip-1.3.0 conflicts with rubyzip (~> 1.2.1)`