### PR TITLE
Use ruby-zip 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+PATH
+  remote: .
+  specs:
+    apktools (0.7.4)
+      rubyzip (~> 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rubyzip (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  apktools!
+
+BUNDLED WITH
+   2.1.4

--- a/apktools.gemspec
+++ b/apktools.gemspec
@@ -18,8 +18,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'apktools'
-  s.version     = '0.7.3'
-  s.date        = '2019-09-27'
+  s.version     = '0.7.4'
+  s.date        = '2020-07-02'
   s.summary     = 'APKTools'
   s.description = 'Library to assist reading resource data out of Android APKs'
   s.authors     = ['Dave Smith']
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
 
   s.executables << 'get_app_version.rb'
   s.executables << 'read_manifest.rb'
-  s.add_runtime_dependency 'rubyzip', '~> 1.3'
+  s.add_runtime_dependency 'rubyzip', '~> 2.0'
 end


### PR DESCRIPTION
related [Conflict with rubyzip 1.3.0 · Issue #24 · devunwired/apktools](https://github.com/devunwired/apktools/issues/24)

In recent fastlane update, fastlane requires `rubyzip ~> 2.0`.
Some fastlane plugin (like fastlane-plugin-aws_s3) uses apktools. So apktools should also support latest ruby-zip.
https://github.com/fastlane/fastlane/releases/tag/2.150.0

I updated ruby-zip dependencies and place `Gemfile`.

This project doesn't have any specs. However, my product seems to work well.
