### PR TITLE
Support APK built with AGP version 8.3

### DIFF
--- a/lib/apktools/apkresources.rb
+++ b/lib/apktools/apkresources.rb
@@ -239,7 +239,7 @@ class ApkResources
     end
 
     entry = res_spec.types.entries[res_index]
-    if entry == nil
+    if entry == nil || entry.values.empty?
       # There is no entry in our table for this resource
       puts "Could not find #{res_spec.types.id} ResType chunk" if DEBUG
       return nil


### PR DESCRIPTION
# Context

When parsing an APK built with [AGP](https://developer.android.com/build/releases/gradle-plugin) version 8.3, APK Resource Toolkit raise an error:

```
undefined method 'key' for nil:NilClass

      return "@#{res_spec.id}/#{entry.values[0].key}"
                                               ^^^^
/vendor/bundle/ruby/3.1.0/gems/apktools-0.7.4/lib/apktools/apkresources.rb:250:in 'get_resource_key'
/vendor/bundle/ruby/3.1.0/gems/apktools-0.7.4/lib/apktools/apkxml.rb:241:in 'parse_xml'
```

This issues does not happen when parsing an APK built with AGP version 8.2.2.

# Changes

- Check if entry values is not empty